### PR TITLE
Disable comment warnings

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -21,6 +21,9 @@ linters:
   ColorVariable:
     enabled: true
 
+  Comment:
+    enabled: false
+
   DebugStatement:
     enabled: true
 


### PR DESCRIPTION
Add the comment options to set to true/false. This way multi-line
comments aren’t always treated as a lint error.
